### PR TITLE
correct typing after np.round in plotting dependencies

### DIFF
--- a/zetapy/plot_dependencies.py
+++ b/zetapy/plot_dependencies.py
@@ -224,10 +224,10 @@ def plotzeta2(vecSpikeTimes1, arrEventTimes1, vecSpikeTimes2, arrEventTimes2, dZ
     # reduce spikes
     if vecSpikeTimes1.size > intPlotSpikeNum or vecSpikeTimes2.size > intPlotSpikeNum:
         dblReduceSpikesBy = min(vecSpikeTimes1.size / intPlotSpikeNum, vecSpikeTimes2.size / intPlotSpikeNum)
-        intPlotSpikeNum1 = np.round(dblReduceSpikesBy * vecSpikeTimes1.size)
-        intPlotSpikeNum2 = np.round(dblReduceSpikesBy * vecSpikeTimes2.size)
-        vecSpikeT1_reduced = vecSpikeTimes1[np.round(np.linspace(0, vecSpikeTimes1.size-1, intPlotSpikeNum1))]
-        vecSpikeT2_reduced = vecSpikeTimes1[np.round(np.linspace(0, vecSpikeTimes2.size-1, intPlotSpikeNum2))]
+        intPlotSpikeNum1 = np.round(dblReduceSpikesBy * vecSpikeTimes1.size).astype(int)
+        intPlotSpikeNum2 = np.round(dblReduceSpikesBy * vecSpikeTimes2.size).astype(int)
+        vecSpikeT1_reduced = vecSpikeTimes1[np.round(np.linspace(0, vecSpikeTimes1.size-1, intPlotSpikeNum1)).astype(int)]
+        vecSpikeT2_reduced = vecSpikeTimes1[np.round(np.linspace(0, vecSpikeTimes2.size-1, intPlotSpikeNum2)).astype(int)]
     else:
         vecSpikeT1_reduced = vecSpikeTimes1
         vecSpikeT2_reduced = vecSpikeTimes2
@@ -375,7 +375,7 @@ def plotzeta(vecSpikeTimes, arrEventTimes, dZETA, dRate,
 
     # top left: raster
     if vecSpikeTimes.size > intPlotSpikeNum:
-        vecSpikeT_reduced = vecSpikeTimes[np.round(np.linspace(0, vecSpikeTimes.size-1, intPlotSpikeNum))]
+        vecSpikeT_reduced = vecSpikeTimes[np.round(np.linspace(0, vecSpikeTimes.size-1, intPlotSpikeNum)).astype(int)]
     else:
         vecSpikeT_reduced = vecSpikeTimes
 


### PR DESCRIPTION
In [`plotzeta2`](https://github.com/JorritMontijn/zetapy/blob/master/zetapy/plot_dependencies.py#L107), `np.round` is used to round to integers.
However, `np.round` does not intrinsically return integers, if any of its arguments is a float, a float is returned.

On lines 227 & 228 in [plot_dependencies.py](https://github.com/JorritMontijn/zetapy/blob/master/zetapy/plot_dependencies.py#L227), this results in a type mismatch:
```python
227        intPlotSpikeNum1 = np.round(dblReduceSpikesBy * vecSpikeTimes1.size)
228        intPlotSpikeNum2 = np.round(dblReduceSpikesBy * vecSpikeTimes2.size)
```

and on lines 233 & 234 in [plot_dependencies.py](https://github.com/JorritMontijn/zetapy/blob/master/zetapy/plot_dependencies.py#L233), the result of `np.linspace` has to be rounded to integers as well:
```python
233        vecSpikeT1_reduced = vecSpikeTimes1[np.round(np.linspace(0, vecSpikeTimes1.size-1, intPlotSpikeNum1))]
234        vecSpikeT2_reduced = vecSpikeTimes1[np.round(np.linspace(0, vecSpikeTimes2.size-1, intPlotSpikeNum2))]
```

The same issue occurs in [plotzeta](https://github.com/JorritMontijn/zetapy/blob/master/zetapy/plot_dependencies.py#L271), but only for the `np.linspace` case.

On line 388 in [plot_dependencies.py](https://github.com/JorritMontijn/zetapy/blob/master/zetapy/plot_dependencies.py#L378):
```python
378        vecSpikeT_reduced = vecSpikeTimes[np.round(np.linspace(0, vecSpikeTimes.size-1, intPlotSpikeNum))]
```

All of these can be fixed by adding `.astype(int)`.

I am using Ubuntu 22.04.3 LTS, with the latest commit of the repository [1bd4862](https://github.com/JorritMontijn/zetapy/commit/1bd4862b3ae5de983859512c0329ef91db01d818), and numpy version 1.24.4.